### PR TITLE
Add branch names to submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,16 @@
 [submodule "rtems"]
 	path = rtems
 	url = https://github.com/grisp/rtems
+	branch = grisp-20171025-patches
 [submodule "rtems-libbsd"]
 	path = rtems-libbsd
 	url = https://github.com/grisp/rtems-libbsd
+	branch = grisp
 [submodule "rtems-source-builder"]
 	path = rtems-source-builder
 	url = git://git.rtems.org/rtems-source-builder.git
+	branch = master
 [submodule "libinih/inih"]
 	path = libinih/inih
 	url = https://github.com/grisp/inih
+	branch = master


### PR DESCRIPTION
Enables updating with `git submodule update --remote` and is more clearly in general.